### PR TITLE
Implement own data store

### DIFF
--- a/id.go
+++ b/id.go
@@ -61,7 +61,7 @@ func (id *ID) Index() (idx uint64, err error) {
 		return
 	}
 	// Grab the index from the first 8 bytes
-	return br.Uint64((*id)[:8])
+	return br.Uint64(id[:8])
 }
 
 // Time will return the time.Time of an ID
@@ -79,7 +79,7 @@ func (id *ID) Time() (t time.Time, err error) {
 		return
 	}
 	// Grab the Unix timestamp from the last 8 bytes
-	if ts, err = br.Int64((*id)[8:]); err != nil {
+	if ts, err = br.Int64(id[8:]); err != nil {
 		return
 	}
 
@@ -96,7 +96,7 @@ func (id *ID) Bytes() (out []byte) {
 		return
 	}
 
-	out = (*id)[:]
+	out = id[:]
 	return
 }
 
@@ -114,19 +114,7 @@ func (id *ID) String() (out string) {
 
 // IsEmpty will return if an ID is empty
 func (id *ID) IsEmpty() (empty bool) {
-	if id == nil {
-		return true
-	}
-
-	// Iterate through each of the ID bytes
-	for i := 0; i < 16; i++ {
-		if (*id)[i] != 0 {
-			// The value at this index is a non-zero value, return early (false)
-			return
-		}
-	}
-	// We made it to the end without finding any non-zero entries, return true
-	return true
+	return id == nil || *id == emptyID
 }
 
 // MarshalJSON is a JSON encoding helper func

--- a/id.go
+++ b/id.go
@@ -7,21 +7,26 @@ import (
 	"github.com/itsmontoya/mum"
 )
 
-// newID will return a new ID with the provided index and the current Unix timestamp
-func newID(idx uint64) (id ID) {
+// newID will return a new ID with the provided index and timestamp
+// Note: If timestamp is set to -1, the current Unix timestamp will
+// be utilized
+func newID(idx uint64, ts int64) (id ID) {
 	// Helper for binary encoding
 	var bw mum.BinaryWriter
-	// Current Unix timestamp (in seconds)
-	// Note: Seconds was decided to be utilized instead of nanoseconds
-	// To aid in an easier integration with Javascript for front-end clients
-	// utilizing idg. Technically, we could utilize milliseconds and maintain
-	// Javascript compatibility. That being said, seconds feels like a much
-	// more universal Unix time reference interval.
-	now := time.Now().Unix()
+	// Check if timestamp is set (or needs to be set)
+	if ts == -1 {
+		// Timestamp is set to -1, set timestamp to current Unix timestamp (in seconds)
+		// Note: Seconds was decided to be utilized instead of nanoseconds
+		// To aid in an easier integration with Javascript for front-end clients
+		// utilizing idg. Technically, we could utilize milliseconds and maintain
+		// Javascript compatibility. That being said, seconds feels like a much
+		// more universal Unix time reference interval.
+		ts = time.Now().Unix()
+	}
 	// Copy index bytes to first 8 bytes
 	copy(id[:8], bw.Uint64(idx))
 	// Copy unix timestamp bytes to last 8 bytes
-	copy(id[8:], bw.Int64(now))
+	copy(id[8:], bw.Int64(ts))
 	return
 }
 

--- a/id.go
+++ b/id.go
@@ -7,11 +7,17 @@ import (
 	"github.com/itsmontoya/mum"
 )
 
+// newID will return a new ID with the provided index and the current Unix timestamp
 func newID(idx uint64) (id ID) {
-	// Current Unix timestamp (in nanoseconds)
-	now := time.Now().Unix()
 	// Helper for binary encoding
 	var bw mum.BinaryWriter
+	// Current Unix timestamp (in seconds)
+	// Note: Seconds was decided to be utilized instead of nanoseconds
+	// To aid in an easier integration with Javascript for front-end clients
+	// utilizing idg. Technically, we could utilize milliseconds and maintain
+	// Javascript compatibility. That being said, seconds feels like a much
+	// more universal Unix time reference interval.
+	now := time.Now().Unix()
 	// Copy index bytes to first 8 bytes
 	copy(id[:8], bw.Uint64(idx))
 	// Copy unix timestamp bytes to last 8 bytes
@@ -80,11 +86,14 @@ func (id *ID) String() (out string) {
 
 // IsEmpty will return if an ID is empty
 func (id *ID) IsEmpty() (empty bool) {
+	// Iterate through each of the ID bytes
 	for i := 0; i < 16; i++ {
 		if (*id)[i] != 0 {
+			// The value at this index is a non-zero value, return early (false)
 			return
 		}
 	}
+	// We made it to the end without finding any non-zero entries, return true
 	return true
 }
 

--- a/id.go
+++ b/id.go
@@ -7,6 +7,18 @@ import (
 	"github.com/itsmontoya/mum"
 )
 
+func newID(idx uint64) (id ID) {
+	// Current Unix timestamp (in nanoseconds)
+	now := time.Now().Unix()
+	// Helper for binary encoding
+	var bw mum.BinaryWriter
+	// Copy index bytes to first 8 bytes
+	copy(id[:8], bw.Uint64(idx))
+	// Copy unix timestamp bytes to last 8 bytes
+	copy(id[8:], bw.Int64(now))
+	return
+}
+
 // ID represents an id
 type ID [16]byte
 

--- a/id.go
+++ b/id.go
@@ -130,14 +130,12 @@ func (id *ID) MarshalJSON() (out []byte, err error) {
 // UnmarshalJSON is a JSON decoding helper func
 func (id *ID) UnmarshalJSON(in []byte) (err error) {
 	var str string
+	// Unmarshal inbound value as a string
 	if err = json.Unmarshal(in, &str); err != nil {
 		return
 	}
-
+	// Strip double-quotation from head and tail
 	stripped := in[1 : len(in)-1]
-	if err = id.parse(stripped); err != nil {
-		return
-	}
-
-	return
+	// Return result of the parsed value
+	return id.parse(stripped)
 }

--- a/id_test.go
+++ b/id_test.go
@@ -15,7 +15,7 @@ func TestIDTime(t *testing.T) {
 	// Get a current timestamp
 	now := time.Now()
 	// Ensure our new ID is at least one millisecond behind our timestamp
-	time.Sleep(time.Millisecond)
+	time.Sleep(time.Second)
 	// Generate a new ID
 	id := newID(0, -1)
 	// Get the time from our ID
@@ -70,4 +70,34 @@ func TestJSON(t *testing.T) {
 	if id != nid {
 		t.Fatalf("ID's do not match: %v / %v", id.Bytes(), nid.Bytes())
 	}
+}
+
+func TestJSONStruct(t *testing.T) {
+	var (
+		ts  testStruct
+		b   []byte
+		err error
+	)
+
+	// Generate an ID with the index starting at 1337
+	id := newID(1337, -1)
+	ts.ID = &id
+	// Marshal ID as JSON
+	if b, err = json.Marshal(&ts); err != nil {
+		t.Fatal(err)
+	}
+
+	var nts testStruct
+	// Parse as JSON to a new ID
+	if err = json.Unmarshal(b, &nts); err != nil {
+		t.Fatal(err)
+	}
+	// Check if the ID's match
+	if *ts.ID != *nts.ID {
+		t.Fatalf("ID's do not match: %v / %v", ts.ID.Bytes(), nts.ID.Bytes())
+	}
+}
+
+type testStruct struct {
+	ID *ID `json:"id"`
 }

--- a/id_test.go
+++ b/id_test.go
@@ -1,0 +1,73 @@
+package idg
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestIDTime(t *testing.T) {
+	var (
+		tt  time.Time
+		err error
+	)
+
+	// Get a current timestamp
+	now := time.Now()
+	// Ensure our new ID is at least one millisecond behind our timestamp
+	time.Sleep(time.Millisecond)
+	// Generate a new ID
+	id := newID(0, -1)
+	// Get the time from our ID
+	if tt, err = id.Time(); err != nil {
+		t.Fatal(err)
+	}
+	// Check to see if our id's time is after our timestamp (it should be)
+	if !tt.After(now) {
+		t.Fatalf("invalid time, should be after initial timestamp: %v / %v", now, tt)
+	}
+}
+
+func TestIDParse(t *testing.T) {
+	var (
+		nid ID
+		err error
+	)
+
+	// Generate an ID with the index starting at 1337
+	id := newID(1337, -1)
+	// Get the string representation of our ID
+	sid := id.String()
+	// Parse the string to a new ID
+	if nid, err = Parse(sid); err != nil {
+		t.Fatal(err)
+	}
+	// Check if the ID's match
+	if id != nid {
+		t.Fatalf("ID's do not match: %v / %v", id.Bytes(), nid.Bytes())
+	}
+}
+
+func TestJSON(t *testing.T) {
+	var (
+		b   []byte
+		err error
+	)
+
+	// Generate an ID with the index starting at 1337
+	id := newID(1337, -1)
+	// Marshal ID as JSON
+	if b, err = json.Marshal(&id); err != nil {
+		t.Fatal(err)
+	}
+
+	var nid ID
+	// Parse as JSON to a new ID
+	if err = json.Unmarshal(b, &nid); err != nil {
+		t.Fatal(err)
+	}
+	// Check if the ID's match
+	if id != nid {
+		t.Fatalf("ID's do not match: %v / %v", id.Bytes(), nid.Bytes())
+	}
+}

--- a/idg.go
+++ b/idg.go
@@ -2,7 +2,6 @@ package idg
 
 import (
 	"encoding/base64"
-	"time"
 
 	"github.com/PathDNA/atoms"
 	"github.com/itsmontoya/mum"
@@ -40,18 +39,6 @@ func (i *IDG) Next() (id ID) {
 	// It is safe to assume that our index is one less than the new value
 	idx := i.idx.Add(1) - 1
 	return newID(idx)
-}
-
-func newID(idx uint64) (id ID) {
-	// Current Unix timestamp (in nanoseconds)
-	now := time.Now().Unix()
-	// Helper for binary encoding
-	var bw mum.BinaryWriter
-	// Copy index bytes to first 8 bytes
-	copy(id[:8], bw.Uint64(idx))
-	// Copy unix timestamp bytes to last 8 bytes
-	copy(id[8:], bw.Int64(now))
-	return
 }
 
 // Parse will parse a string id

--- a/idg.go
+++ b/idg.go
@@ -40,7 +40,7 @@ func (i *IDG) Next() (id ID) {
 	// We atomically increment our current index by one.
 	// It is safe to assume that our index is one less than the new value
 	idx := i.idx.Add(1) - 1
-	return newID(idx)
+	return newID(idx, -1)
 }
 
 // Parse will parse a string id

--- a/idg.go
+++ b/idg.go
@@ -18,6 +18,8 @@ var (
 	b64 = base64.RawURLEncoding
 	// String length
 	strLen = b64.EncodedLen(16)
+	// Empty ID used for matching
+	emptyID = ID{}
 )
 
 // New will return a new ID generator

--- a/idg.go
+++ b/idg.go
@@ -15,10 +15,8 @@ const (
 )
 
 var (
-	// Base64 encoder alias
-	b64 = base64.RawURLEncoding
 	// String length
-	strLen = b64.EncodedLen(16)
+	strLen = base64.RawURLEncoding.EncodedLen(16)
 )
 
 // New will return a new ID generator

--- a/idg.go
+++ b/idg.go
@@ -14,8 +14,10 @@ const (
 )
 
 var (
+	// Base64 RawURLEncoding alias
+	b64 = base64.RawURLEncoding
 	// String length
-	strLen = base64.RawURLEncoding.EncodedLen(16)
+	strLen = b64.EncodedLen(16)
 )
 
 // New will return a new ID generator

--- a/idg.go
+++ b/idg.go
@@ -26,7 +26,7 @@ func New(idx uint64) (idg IDG) {
 	return
 }
 
-// IDG is an ID generator
+// IDG is an non-persistent atomic ID generator
 type IDG struct {
 	mux atoms.Mux
 	// Helper for binary encoding
@@ -41,10 +41,4 @@ func (i *IDG) Next() (id ID) {
 	// It is safe to assume that our index is one less than the new value
 	idx := i.idx.Add(1) - 1
 	return newID(idx, -1)
-}
-
-// Parse will parse a string id
-func Parse(in string) (id ID, err error) {
-	err = id.parse([]byte(in))
-	return
 }

--- a/idg_test.go
+++ b/idg_test.go
@@ -49,15 +49,6 @@ func BenchmarkIDG_Gen(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func BenchmarkUUID_Gen(b *testing.B) {
-	ug := uuid.NewGen()
-	for i := 0; i < b.N; i++ {
-		uuidSink = ug.New()
-	}
-
-	b.ReportAllocs()
-}
-
 func BenchmarkIDG_Gen_Para(b *testing.B) {
 	idg := New(0)
 	b.RunParallel(func(pb *testing.PB) {
@@ -65,6 +56,15 @@ func BenchmarkIDG_Gen_Para(b *testing.B) {
 			idSink = idg.Next()
 		}
 	})
+
+	b.ReportAllocs()
+}
+
+func BenchmarkUUID_Gen(b *testing.B) {
+	ug := uuid.NewGen()
+	for i := 0; i < b.N; i++ {
+		uuidSink = ug.New()
+	}
 
 	b.ReportAllocs()
 }

--- a/idg_test.go
+++ b/idg_test.go
@@ -1,10 +1,8 @@
 package idg
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/missionMeteora/uuid"
 )
@@ -14,28 +12,7 @@ var (
 	uuidSink uuid.UUID
 )
 
-func TestTime(t *testing.T) {
-	var (
-		tt  time.Time
-		err error
-	)
-
-	// Get a current timestamp
-	now := time.Now()
-	// Ensure our new ID is at least one millisecond behind our timestamp
-	time.Sleep(time.Millisecond)
-	// Generate a new ID
-	id := newID(0)
-	// Get the time from our ID
-	if tt, err = id.Time(); err != nil {
-		t.Fatal(err)
-	}
-	// Check to see if our id's time is after our timestamp (it should be)
-	if !tt.After(now) {
-		t.Fatalf("invalid time, should be after initial timestamp: %v / %v", now, tt)
-	}
-}
-func TestIndexing(t *testing.T) {
+func TestIDGIndexing(t *testing.T) {
 	var err error
 	// Generate new ID with an index starting at 3
 	idg := New(3)
@@ -52,50 +29,6 @@ func TestIndexing(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
-	var (
-		nid ID
-		err error
-	)
-
-	// Generate an ID with the index starting at 1337
-	id := newID(1337)
-	// Get the string representation of our ID
-	sid := id.String()
-	// Parse the string to a new ID
-	if nid, err = Parse(sid); err != nil {
-		t.Fatal(err)
-	}
-	// Check if the ID's match
-	if id != nid {
-		t.Fatalf("ID's do not match: %v / %v", id.Bytes(), nid.Bytes())
-	}
-}
-
-func TestJSON(t *testing.T) {
-	var (
-		b   []byte
-		err error
-	)
-
-	// Generate an ID with the index starting at 1337
-	id := newID(1337)
-	// Marshal ID as JSON
-	if b, err = json.Marshal(&id); err != nil {
-		t.Fatal(err)
-	}
-
-	var nid ID
-	// Parse as JSON to a new ID
-	if err = json.Unmarshal(b, &nid); err != nil {
-		t.Fatal(err)
-	}
-	// Check if the ID's match
-	if id != nid {
-		t.Fatalf("ID's do not match: %v / %v", id.Bytes(), nid.Bytes())
-	}
-}
-
 func testIndex(id ID, expected uint64) (err error) {
 	var idx uint64
 	if idx, err = id.Index(); err != nil {
@@ -107,7 +40,7 @@ func testIndex(id ID, expected uint64) (err error) {
 	return
 }
 
-func BenchmarkGenerationIDG(b *testing.B) {
+func BenchmarkIDG_Gen(b *testing.B) {
 	idg := New(0)
 	for i := 0; i < b.N; i++ {
 		idSink = idg.Next()
@@ -116,7 +49,7 @@ func BenchmarkGenerationIDG(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func BenchmarkGenerationUUID(b *testing.B) {
+func BenchmarkUUID_Gen(b *testing.B) {
 	ug := uuid.NewGen()
 	for i := 0; i < b.N; i++ {
 		uuidSink = ug.New()
@@ -125,7 +58,7 @@ func BenchmarkGenerationUUID(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func BenchmarkGenerationParallelIDG(b *testing.B) {
+func BenchmarkIDG_Gen_Para(b *testing.B) {
 	idg := New(0)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
@@ -136,7 +69,7 @@ func BenchmarkGenerationParallelIDG(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func BenchmarkGenerationParallelUUID(b *testing.B) {
+func BenchmarkUUID_Gen_Para(b *testing.B) {
 	ug := uuid.NewGen()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/pidg.go
+++ b/pidg.go
@@ -1,0 +1,108 @@
+package idg
+
+import (
+	"io"
+	"os"
+	"path"
+
+	"github.com/PathDNA/atoms"
+	"github.com/itsmontoya/mum"
+)
+
+//NewPersistent will return a new ID generator
+func NewPersistent(key, dir string) (pidg *PIDG, err error) {
+	var p PIDG
+	// Set file
+	if err = p.setFile(key, dir); err != nil {
+		return
+	}
+	// Set encoder
+	p.enc = mum.NewEncoder(p.pf)
+	pidg = &p
+	return
+}
+
+// PIDG is an non-persistent atomic ID generator
+type PIDG struct {
+	mux atoms.Mux
+	// Helper for binary encoding
+	bw mum.BinaryWriter
+	// Persistance file
+	pf *os.File
+	// Encoder writer
+	enc *mum.Encoder
+	// Current index
+	idx uint64
+}
+
+// setFile will set the internal persistence file
+func (p *PIDG) setFile(key, dir string) (err error) {
+	// Ensure all directories exist
+	if err = os.MkdirAll(dir, 0744); err != nil {
+		return
+	}
+
+	// Filepath
+	fp := path.Join(dir, key+".idg")
+	// Open (or create) file with read/write functionality
+	if p.pf, err = os.OpenFile(fp, os.O_CREATE|os.O_RDWR, 0644); err != nil {
+		return
+	}
+	// Create a temporary decoder to read initial value
+	dec := mum.NewDecoder(p.pf)
+	var idx uint64
+	// Decode a uint64 value from the file
+	if idx, err = dec.Uint64(); err != nil {
+		if err == io.EOF {
+			// io.EOF means we do not yet have any index data saved, our default index of 0 is
+			// our intended value, error does not need to be reported
+			err = nil
+		}
+
+		return
+	}
+	// Current index would be the NEXT index following the last persisted value
+	p.idx = idx + 1
+	return
+}
+
+// persist will store the current index to disk
+// Note: This is NOT thread-safe, please ensure locking is
+// handled by the calling func
+func (p *PIDG) persist() (err error) {
+	if _, err = p.pf.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+
+	return p.enc.Uint64(p.idx)
+}
+
+// Next will return the next id
+func (p *PIDG) Next() (id ID, err error) {
+	var idx uint64
+	p.mux.Update(func() {
+		idx = p.idx
+		// Perist value to disk
+		if err = p.persist(); err != nil {
+			return
+		}
+		// Increment index value
+		p.idx++
+	})
+	// Break early if error exists
+	if err != nil {
+		return
+	}
+	// Set id with the retrieved index (utilizing a current timestamp)
+	id = newID(idx, -1)
+	return
+}
+
+// Close will close the internal file
+func (p *PIDG) Close() (err error) {
+	p.mux.Update(func() {
+		err = p.pf.Close()
+	})
+
+	return
+}

--- a/pidg_test.go
+++ b/pidg_test.go
@@ -1,0 +1,115 @@
+package idg
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPIDGIndexing(t *testing.T) {
+	var (
+		pidg *PIDG
+		id   ID
+		err  error
+	)
+	defer os.RemoveAll("./test_data")
+
+	// Initialize a persistent id generator
+	if pidg, err = NewPersistent("test1", "./test_data"); err != nil {
+		t.Fatal(err)
+	}
+	defer pidg.Close()
+
+	if id, err = pidg.Next(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testIndex(id, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if id, err = pidg.Next(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testIndex(id, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	if id, err = pidg.Next(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testIndex(id, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	if err = pidg.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-initialize a persistent id generator to test data loading
+	if pidg, err = NewPersistent("test1", "./test_data"); err != nil {
+		t.Fatal(err)
+	}
+
+	if id, err = pidg.Next(); err != nil {
+		t.Fatal(err)
+	}
+	// Value should now be 3
+	if err = testIndex(id, 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkPIDG_Gen(b *testing.B) {
+	var (
+		pidg *PIDG
+		err  error
+	)
+	defer os.RemoveAll("./test_data")
+
+	// Generate new ID with an index starting at 3
+	if pidg, err = NewPersistent("test1", "./test_data"); err != nil {
+		// Error encountered, bail out
+		b.Fatal(err)
+	}
+	defer pidg.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if idSink, err = pidg.Next(); err != nil {
+			// Error encountered, bail out
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+}
+
+func BenchmarkPIDG_Gen_Para(b *testing.B) {
+	var (
+		pidg *PIDG
+		err  error
+	)
+	defer os.RemoveAll("./test_data")
+
+	// Generate new ID with an index starting at 3
+	if pidg, err = NewPersistent("test1", "./test_data"); err != nil {
+		// Error encountered, bail out
+		b.Fatal(err)
+	}
+	defer pidg.Close()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		var err error
+		for pb.Next() {
+			if idSink, err = pidg.Next(); err != nil {
+				b.Fatal()
+			}
+		}
+	})
+
+	b.ReportAllocs()
+}

--- a/tidg.go
+++ b/tidg.go
@@ -16,7 +16,7 @@ func NewTIDG(key string, fm turtleDB.FuncsMap) (t TIDG) {
 	return
 }
 
-// TIDG is an non-persistent atomic ID generator
+// TIDG is a persistent turtleDB-based ID generator
 type TIDG struct {
 	// Helper for binary encoding
 	bw mum.BinaryWriter

--- a/tidg.go
+++ b/tidg.go
@@ -1,0 +1,100 @@
+package idg
+
+import (
+	"encoding/json"
+
+	"github.com/PathDNA/turtleDB"
+	"github.com/itsmontoya/mum"
+)
+
+const tidgBkt = "__idg"
+
+// NewTIDG will return a new turtleDB-backed ID generator
+func NewTIDG(key string, fm turtleDB.FuncsMap) (t TIDG) {
+	t.key = key
+	fm.Put(tidgBkt, marshalIndex, unmarshalIndex)
+	return
+}
+
+// TIDG is an non-persistent atomic ID generator
+type TIDG struct {
+	// Helper for binary encoding
+	bw mum.BinaryWriter
+	// Key utilized for the index value
+	key string
+}
+
+func (t *TIDG) getIndex(bkt turtleDB.Bucket) (idx uint64, err error) {
+	var val turtleDB.Value
+	// Get value set for our TIDG.key
+	if val, err = bkt.Get(t.key); err != nil {
+		if err == turtleDB.ErrKeyDoesNotExist {
+			// If the key does not exist, we can set error to nil
+			// An index of 0 will be just as intended
+			err = nil
+		}
+
+		return
+	}
+
+	var ok bool
+	if idx, ok = val.(uint64); !ok {
+		// Index is not the right type, abort!
+		err = turtleDB.ErrInvalidType
+		return
+	}
+
+	return
+}
+
+// Next will return the next id
+func (t *TIDG) Next(txn turtleDB.Txn) (id ID, err error) {
+	var bkt turtleDB.Bucket
+	// Ensure idg bucket exists
+	if bkt, err = txn.Create("__idg"); err != nil {
+		// Error encountered while creating idg bucket
+		return
+	}
+
+	var idx uint64
+	// Get current index
+	if idx, err = t.getIndex(bkt); err != nil {
+		// We encountered an error while getting, return
+		return
+	}
+
+	// Increment index value and set it as the index for our TIDG.key
+	if err = bkt.Put(t.key, idx+1); err != nil {
+		// We encountered an error while putting, return
+		return
+	}
+
+	id = newID(idx, -1)
+	return
+}
+
+// marshalIndex is an encoding helper function for turtleDB
+func marshalIndex(val turtleDB.Value) (b []byte, err error) {
+	var (
+		idx uint64
+		ok  bool
+	)
+
+	if idx, ok = val.(uint64); !ok {
+		err = turtleDB.ErrInvalidType
+		return
+	}
+
+	return json.Marshal(idx)
+}
+
+// unmarshalIndex is an decoding helper function for turtleDB
+func unmarshalIndex(b []byte) (val turtleDB.Value, err error) {
+	var idx uint64
+	if err = json.Unmarshal(b, &idx); err != nil {
+		return
+	}
+
+	val = idx
+	return
+}

--- a/tidg_test.go
+++ b/tidg_test.go
@@ -1,0 +1,99 @@
+package idg
+
+import (
+	"os"
+	"testing"
+
+	"github.com/PathDNA/turtleDB"
+)
+
+func TestTIDGIndexing(t *testing.T) {
+	var (
+		db  turtleDB.DB
+		id  ID
+		err error
+	)
+
+	// Initialize basic funcsmap
+	fm := turtleDB.FuncsMap{}
+	// Initialize a new instance of tidg
+	tidg := NewTIDG("test", fm)
+
+	if db, err = turtleDB.New("tidg_test", "./test_data", fm); err != nil {
+		return
+	}
+	defer os.RemoveAll("./test_data")
+	defer db.Close()
+
+	// Increment index four times
+	if err = db.Update(func(txn turtleDB.Txn) (err error) {
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		return
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure our index is the proper value of 3 (4 entries, starting at an index of 0)
+	if err = testIndex(id, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Increment index four times
+	if err = db.Update(func(txn turtleDB.Txn) (err error) {
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		if id, err = tidg.Next(txn); err != nil {
+			return
+		}
+
+		return
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure our index is the proper value of 7 (8 entries, starting at an index of 0)
+	if err = testIndex(id, 7); err != nil {
+		t.Fatal(err)
+	}
+
+	// Close database, testing for persistence
+	if err = db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-initialize database
+	if db, err = turtleDB.New("tidg_test", "./test_data", nil); err != nil {
+		return
+	}
+
+	// Ensure our index is still proper after DB reboot
+	if err = testIndex(id, 7); err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,7 @@
+package idg
+
+// Parse will parse a string id
+func Parse(in string) (id ID, err error) {
+	err = id.parse([]byte(in))
+	return
+}


### PR DESCRIPTION
The purpose of this branch was to see if we could improve the persistent-version speed by implementing a custom super light-weight persistence store.

```bash
# IDG (non-persistent)
BenchmarkIDG_Gen-16         20000000       98.1 ns/op       0 B/op     0 allocs/op
BenchmarkIDG_Gen_Para-16    30000000       35.2 ns/op       0 B/op     0 allocs/op
# missionMeteora/uuid (non-persistent)
BenchmarkUUID_Gen-16        20000000        118 ns/op       0 B/op     0 allocs/op
BenchmarkUUID_Gen_Para-16    5000000        308 ns/op       0 B/op     0 allocs/op
# Custom persistence module
BenchmarkPIDG_Gen-16         1000000       1046 ns/op       0 B/op     0 allocs/op
BenchmarkPIDG_Gen_Para-16     500000       2178 ns/op       0 B/op     0 allocs/op
# TurtleDB persistence module
BenchmarkTIDG_Gen-16            1000    2375071 ns/op    2373 B/op    24 allocs/op
BenchmarkTIDG_Gen_Para-16       1000    2265625 ns/op    2373 B/op    24 allocs/op
```

The performance speaks for itself, the benefits of the custom store allow us to maintain ACID safety with zero memory overhead and minimal slowdown. 